### PR TITLE
feat: make nf.ni.ls API key optional

### DIFF
--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -17,7 +17,7 @@
     <repositories>
         <repository>
             <id>bungeecord-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -14,18 +14,11 @@
     <name>NetworkFilterBungee</name>
     <description/>
 
-    <repositories>
-        <repository>
-            <id>bungeecord-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/common/src/main/java/ls/ni/networkfilter/common/config/service/types/NetworkFilterServiceSettings.java
+++ b/common/src/main/java/ls/ni/networkfilter/common/config/service/types/NetworkFilterServiceSettings.java
@@ -1,15 +1,15 @@
 package ls.ni.networkfilter.common.config.service.types;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.Nullable;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class NetworkFilterServiceSettings {
 
-    @NotNull
+    @Nullable
     private String key;
 }

--- a/common/src/main/java/ls/ni/networkfilter/common/filter/types/NetworkFilterFilterService.java
+++ b/common/src/main/java/ls/ni/networkfilter/common/filter/types/NetworkFilterFilterService.java
@@ -1,6 +1,6 @@
 package ls.ni.networkfilter.common.filter.types;
 
-import jakarta.validation.constraints.NotBlank;
+import kong.unirest.core.HttpRequestWithBody;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
 import kong.unirest.core.Unirest;
@@ -10,17 +10,18 @@ import ls.ni.networkfilter.common.filter.FilterException;
 import ls.ni.networkfilter.common.filter.FilterResult;
 import ls.ni.networkfilter.common.filter.FilterService;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
 
 public class NetworkFilterFilterService implements FilterService {
 
-    @NotNull
+    @Nullable
     private final String apiKey;
 
-    public NetworkFilterFilterService(@NotNull @NotBlank String apiKey) {
-        this.apiKey = apiKey;
+    public NetworkFilterFilterService(@Nullable String apiKey) {
+        this.apiKey = apiKey != null && !apiKey.isBlank() ? apiKey : null;
     }
 
     @Override
@@ -30,9 +31,14 @@ public class NetworkFilterFilterService implements FilterService {
 
     @Override
     public @NotNull FilterResult check(@NotNull String ip) {
-        HttpResponse<JsonNode> response = Unirest.post("https://nf.ni.ls/api/check")
-                .header("X-API-KEY", this.apiKey)
-                .header("Content-Type", "application/x-www-form-urlencoded")
+        HttpRequestWithBody request = Unirest.post("https://nf.ni.ls/api/check")
+                .header("Content-Type", "application/x-www-form-urlencoded");
+
+        if (this.apiKey != null) {
+            request.header("X-API-KEY", this.apiKey);
+        }
+
+        HttpResponse<JsonNode> response = request
                 .field("ip", ip)
                 .asJson();
 

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -20,7 +20,7 @@ caches:
 services:
   # https://nf.ni.ls
   networkfilter:
-    # Required
+    # Optional, needed if rate-limited
     key: ""
 
   # https://ipapi.is


### PR DESCRIPTION
The nf.ni.ls service no longer requires an API key to function. The key
is now only sent when configured, matching the behavior of the ipapi.is
service.