### PR TITLE
feat(cache): add configurable api result cache

### DIFF
--- a/common/src/main/java/ls/ni/networkfilter/common/NetworkFilterCommon.java
+++ b/common/src/main/java/ls/ni/networkfilter/common/NetworkFilterCommon.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.text.MessageFormat;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -116,69 +115,21 @@ public class NetworkFilterCommon {
     private @NotNull NetworkFilterResult check(@NotNull String ip) {
         long startTime = System.nanoTime();
 
-        // cache
-        Optional<FilterResult> cached = Optional.ofNullable(this.filterCache.getIfPresent(ip));
-        if (cached.isPresent()) {
-            this.debug("[{0}] Result is cached: {1}", ip, cached.get());
+        FilterResult cached = this.filterCache.getIfPresent(ip);
+        if (cached != null) {
+            this.debug("[{0}] Result is cached: {1}", ip, cached);
 
             return new NetworkFilterResult(
-                    cached.get().block(),
-                    cached.get().asn(),
-                    cached.get().org(),
+                    cached.block(),
+                    cached.asn(),
+                    cached.org(),
                     ip,
                     true,
                     TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime)
             );
         }
 
-        // ignore
-        try {
-            for (String network : this.configManager.getConfig().getIgnore().getNetworks()) {
-                if (!network.contains("/")) {
-                    this.logger.warning(network + " is not in CIDR notation, assuming /32");
-                    network = network + "/32";
-                }
-
-                SubnetUtils subnetUtils = new SubnetUtils(network);
-
-                if (subnetUtils.getInfo().isInRange(ip)) {
-                    FilterResult filterResult = new FilterResult(false, null, null);
-
-                    this.filterCache.put(ip, filterResult);
-
-                    this.debug("[{0}] IP is in ignored range: {1}", ip, network);
-
-                    return new NetworkFilterResult(
-                            false,
-                            -1,
-                            "Ignored Network",
-                            ip,
-                            false,
-                            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime)
-                    );
-                }
-            }
-        } catch (Throwable t) {
-            this.logger.log(Level.SEVERE, "Error while checking inetAddress for ignored", t);
-        }
-
-        // check
-        FilterResult filterResult;
-        try {
-            filterResult = this.filterService.check(ip);
-        } catch (FilterException e) {
-            this.logger.log(Level.SEVERE, "Could not check ip " + ip + " (status: " + e.getCode() + ", body: " + e.getBody().toString() + ")", e);
-
-            // TODO: make configurable (something like "blockOnFilterServiceError") - should apply on rate limit?
-            filterResult = new FilterResult(false, null, null);
-        } catch (Throwable t) {
-            this.logger.log(Level.SEVERE, "Could not check ip " + ip, t);
-
-            // TODO: make configurable (something like "blockOnUnexpectedError")
-            filterResult = new FilterResult(false, null, null);
-        }
-
-        this.filterCache.put(ip, filterResult);
+        FilterResult filterResult = this.filterCache.get(ip, this::loadFilterResult);
 
         this.debug("[{0}] Requested: {1}", ip, filterResult);
 
@@ -190,6 +141,42 @@ public class NetworkFilterCommon {
                 false,
                 TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime)
         );
+    }
+
+    private @NotNull FilterResult loadFilterResult(@NotNull String ip) {
+
+        try {
+            for (String network : this.configManager.getConfig().getIgnore().getNetworks()) {
+                if (!network.contains("/")) {
+                    this.logger.warning(network + " is not in CIDR notation, assuming /32");
+                    network = network + "/32";
+                }
+
+                SubnetUtils subnetUtils = new SubnetUtils(network);
+
+                if (subnetUtils.getInfo().isInRange(ip)) {
+                    this.debug("[{0}] IP is in ignored range: {1}", ip, network);
+
+                    return new FilterResult(false, -1, "Ignored Network");
+                }
+            }
+        } catch (Throwable t) {
+            this.logger.log(Level.SEVERE, "Error while checking inetAddress for ignored", t);
+        }
+
+        try {
+            return this.filterService.check(ip);
+        } catch (FilterException e) {
+            this.logger.log(Level.SEVERE, "Could not check ip " + ip + " (status: " + e.getCode() + ", body: " + e.getBody().toString() + ")", e);
+
+            // TODO: make configurable (something like "blockOnFilterServiceError") - should apply on rate limit?
+            return new FilterResult(false, null, null);
+        } catch (Throwable t) {
+            this.logger.log(Level.SEVERE, "Could not check ip " + ip, t);
+
+            // TODO: make configurable (something like "blockOnUnexpectedError")
+            return new FilterResult(false, null, null);
+        }
     }
 
     public void sendNotify(NetworkFilterResult result, String name, UUID uuid) {

--- a/common/src/main/java/ls/ni/networkfilter/common/cache/CacheFactory.java
+++ b/common/src/main/java/ls/ni/networkfilter/common/cache/CacheFactory.java
@@ -4,6 +4,7 @@ import ls.ni.networkfilter.common.cache.types.CaffeineCache;
 import ls.ni.networkfilter.common.cache.types.NoopCache;
 import ls.ni.networkfilter.common.cache.types.RedisCache;
 import ls.ni.networkfilter.common.config.Config;
+import ls.ni.networkfilter.common.config.cache.types.ApiCacheSettings;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
@@ -11,6 +12,17 @@ import java.time.Duration;
 public class CacheFactory {
 
     public static Cache create(@NotNull Config config) {
+        ApiCacheSettings apiCache = config.getApiCache();
+        if (apiCache != null && Boolean.TRUE.equals(apiCache.getEnabled())) {
+            long maximumSize = apiCache.getMaximumSize() != null ? apiCache.getMaximumSize() : 1000L;
+            long cacheTimeMinutes = apiCache.getCacheTimeMinutes() != null ? apiCache.getCacheTimeMinutes() : 60L;
+
+            return new CaffeineCache(
+                    maximumSize,
+                    Duration.ofMinutes(cacheTimeMinutes)
+            );
+        }
+
         return switch (config.getCache()) {
             case DISABLED -> new NoopCache();
             case LOCAL -> {

--- a/common/src/main/java/ls/ni/networkfilter/common/config/Config.java
+++ b/common/src/main/java/ls/ni/networkfilter/common/config/Config.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import ls.ni.networkfilter.common.config.cache.CacheSettings;
 import ls.ni.networkfilter.common.config.cache.CacheType;
+import ls.ni.networkfilter.common.config.cache.types.ApiCacheSettings;
 import ls.ni.networkfilter.common.config.consequence.ConsequenceSettings;
 import ls.ni.networkfilter.common.config.ignore.IgnoreSettings;
 import ls.ni.networkfilter.common.config.notify.NotifySettings;
@@ -36,6 +37,9 @@ public class Config {
     @Valid
     @NotNull
     private CacheSettings caches;
+
+    @Valid
+    private ApiCacheSettings apiCache;
 
     @Valid
     @NotNull

--- a/common/src/main/java/ls/ni/networkfilter/common/config/cache/types/ApiCacheSettings.java
+++ b/common/src/main/java/ls/ni/networkfilter/common/config/cache/types/ApiCacheSettings.java
@@ -1,0 +1,17 @@
+package ls.ni.networkfilter.common.config.cache.types;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiCacheSettings {
+
+    private Boolean enabled;
+
+    private Long maximumSize;
+
+    private Long cacheTimeMinutes;
+}

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -17,6 +17,13 @@ caches:
     uri: "redis://user:password@localhost:6379"
     cacheTimeMinutes: 15
 
+# Local in-memory cache for API/filter results.
+# If enabled, this is checked before every API request.
+apiCache:
+  enabled: true
+  maximumSize: 1000
+  cacheTimeMinutes: 60
+
 services:
   # https://nf.ni.ls
   networkfilter:


### PR DESCRIPTION
Adds a configurable local cache for API results so repeated checks for the same IP no longer consume a new request every time. Results are now cached with a configurable TTL via apiCache in the config.